### PR TITLE
Update GitHub Actions Checkout

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/richnav.yml
+++ b/.github/workflows/richnav.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -10,7 +10,7 @@ jobs:
   toc:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: TOC Generator
         uses: technote-space/toc-generator@v4
         with:


### PR DESCRIPTION
Partially resolves #37 

Updates GitHub actions/checkout to version 4.

I couldn't seem to find a Node 20 version of technote-space/toc-generator so we'll have to update that in a follow up PR. 