### PR TITLE
Add missing migration and fix dotnet-ef tool

### DIFF
--- a/src/Infrastructure/Data/Migrations/20250207163746_MissingMigration20250207.Designer.cs
+++ b/src/Infrastructure/Data/Migrations/20250207163746_MissingMigration20250207.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Microsoft.eShopWeb.Infrastructure.Data;
 
@@ -11,9 +12,11 @@ using Microsoft.eShopWeb.Infrastructure.Data;
 namespace Microsoft.eShopWeb.Infrastructure.Data.Migrations
 {
     [DbContext(typeof(CatalogContext))]
-    partial class CatalogContextModelSnapshot : ModelSnapshot
+    [Migration("20250207163746_MissingMigration20250207")]
+    partial class MissingMigration20250207
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Infrastructure/Data/Migrations/20250207163746_MissingMigration20250207.cs
+++ b/src/Infrastructure/Data/Migrations/20250207163746_MissingMigration20250207.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Microsoft.eShopWeb.Infrastructure.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class MissingMigration20250207 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ShipToAddress_State",
+                table: "Orders",
+                type: "nvarchar(60)",
+                maxLength: 60,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(60)",
+                oldMaxLength: 60,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ItemOrdered_ProductName",
+                table: "OrderItems",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50,
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ItemOrdered_PictureUri",
+                table: "OrderItems",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ItemOrdered_CatalogItemId",
+                table: "OrderItems",
+                type: "int",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "int",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Catalog",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "ShipToAddress_State",
+                table: "Orders",
+                type: "nvarchar(60)",
+                maxLength: 60,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(60)",
+                oldMaxLength: 60);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ItemOrdered_ProductName",
+                table: "OrderItems",
+                type: "nvarchar(50)",
+                maxLength: 50,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(50)",
+                oldMaxLength: 50);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "ItemOrdered_PictureUri",
+                table: "OrderItems",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "ItemOrdered_CatalogItemId",
+                table: "OrderItems",
+                type: "int",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "int");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Description",
+                table: "Catalog",
+                type: "nvarchar(max)",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(max)");
+        }
+    }
+}

--- a/src/Web/.config/dotnet-tools.json
+++ b/src/Web/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-ef": {
-      "version": "8.0.0",
+      "version": "9.0.1",
       "commands": [
         "dotnet-ef"
       ]


### PR DESCRIPTION
Related to #149 

The issue reported has 2 pain points:
- Wrong version of the `dotnet-ef` tool
- Missing migration

The `dotnet-ef` tool was locked to version 8 in the **src\Web\.config\dotnet-tools.json**. This is now updated to 9.0.1.

The missing migration includes the following changes:
- Making `ShipToAddress_State` on `Orders`  non-nullable
- Making `ItemOrdered_ProductName` on `OrderItems ` non-nullable
- Making `ItemOrdered_PictureUri` on `OrderItems`  non-nullable
- Making `ItemOrdered_CatalogItemId` on `OrderItems` non-nullable
- Making `Description` on `Catalog` non-nullable

Talking with @ardalis, all the data is seeded. So we are not concerned about the potential loss of data that is mentioned when we generated the migration.