### PR TITLE
Dealing with the warnings in the build

### DIFF
--- a/src/ApplicationCore/Exceptions/EmptyBasketOnCheckoutException.cs
+++ b/src/ApplicationCore/Exceptions/EmptyBasketOnCheckoutException.cs
@@ -9,10 +9,6 @@ public class EmptyBasketOnCheckoutException : Exception
     {
     }
 
-    protected EmptyBasketOnCheckoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)
-    {
-    }
-
     public EmptyBasketOnCheckoutException(string message) : base(message)
     {
     }

--- a/tests/IntegrationTests/Repositories/BasketRepositoryTests/SetQuantities.cs
+++ b/tests/IntegrationTests/Repositories/BasketRepositoryTests/SetQuantities.cs
@@ -35,6 +35,6 @@ public class SetQuantities
 
         await basketService.SetQuantities(BasketBuilder.BasketId, new Dictionary<string, int>() { { BasketBuilder.BasketId.ToString(), 0 } });
 
-        Assert.Equal(0, basket.Items.Count);
+        Assert.Empty(basket.Items);
     }
 }

--- a/tests/UnitTests/ApplicationCore/Entities/BasketTests/BasketRemoveEmptyItems.cs
+++ b/tests/UnitTests/ApplicationCore/Entities/BasketTests/BasketRemoveEmptyItems.cs
@@ -15,7 +15,6 @@ public class BasketRemoveEmptyItems
         var basket = new Basket(_buyerId);
         basket.AddItem(_testCatalogItemId, _testUnitPrice, 0);
         basket.RemoveEmptyItems();
-
-        Assert.Equal(0, basket.Items.Count);
+        Assert.Empty(basket.Items);
     }
 }

--- a/tests/UnitTests/ApplicationCore/Specifications/CustomerOrdersWithItemsSpecification.cs
+++ b/tests/UnitTests/ApplicationCore/Specifications/CustomerOrdersWithItemsSpecification.cs
@@ -19,7 +19,7 @@ public class CustomerOrdersWithItemsSpecification
 
         Assert.NotNull(result);
         Assert.NotNull(result.OrderItems);
-        Assert.Equal(1, result.OrderItems.Count);
+        Assert.Single(result.OrderItems);
         Assert.NotNull(result.OrderItems.FirstOrDefault()?.ItemOrdered);
     }
 
@@ -32,7 +32,7 @@ public class CustomerOrdersWithItemsSpecification
 
         Assert.NotNull(result);
         Assert.Equal(2, result.Count);
-        Assert.Equal(1, result[0].OrderItems.Count);
+        Assert.Single(result[0].OrderItems);
         Assert.NotNull(result[0].OrderItems.FirstOrDefault()?.ItemOrdered);
         Assert.Equal(2, result[1].OrderItems.Count);
         Assert.NotNull(result[1].OrderItems.ToList()[0].ItemOrdered);


### PR DESCRIPTION
- Removing ` protected EmptyBasketOnCheckoutException(System.Runtime.Serialization.SerializationInfo info, System.Runtime.Serialization.StreamingContext context) : base(info, context)`
- Replacing some `Assert.Equal` statements on checking a Count to be 1 with `Assert.Single`
- Replacing some `Assert.Equal` statements on checking a Count to be 0 with `Assert.Empty`