### PR TITLE
Replace Azure SQL Edge with a SQL Server SKU - closes #135

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - "sqlserver"
   sqlserver:
-    image: mcr.microsoft.com/azure-sql-edge
+    image: mcr.microsoft.com/mssql/server:2022-latest
     ports:
       - "1433:1433"
     environment:


### PR DESCRIPTION
- Replaces `azure-sql-edge` with SQL Server 2022's `latest` image.

- Went with SQL Server 2022 since it is the current version.