### PR TITLE
Adding a Product Manager Role

### DIFF
--- a/src/BlazorAdmin/Pages/CatalogItemPage/List.razor
+++ b/src/BlazorAdmin/Pages/CatalogItemPage/List.razor
@@ -1,5 +1,5 @@
 ﻿@page "/admin"
-@attribute [Authorize(Roles = BlazorShared.Authorization.Constants.Roles.ADMINISTRATORS)]
+@attribute [Authorize(Roles = BlazorShared.Authorization.Constants.RoleCombinations.ADMIN_PORTAL_ROLES)]
 @inherits BlazorAdmin.Helpers.BlazorComponent
 @namespace BlazorAdmin.Pages.CatalogItemPage
 

--- a/src/BlazorAdmin/Shared/MainLayout.razor
+++ b/src/BlazorAdmin/Shared/MainLayout.razor
@@ -4,7 +4,7 @@
 @inherits BlazorAdmin.Helpers.BlazorLayoutComponent
 
 
-<AuthorizeView Roles=@BlazorShared.Authorization.Constants.Roles.ADMINISTRATORS>
+<AuthorizeView Roles=@BlazorShared.Authorization.Constants.RoleCombinations.ADMIN_PORTAL_ROLES>
     <div class="sidebar">
         <NavMenu />
     </div>

--- a/src/BlazorShared/Authorization/Constants.cs
+++ b/src/BlazorShared/Authorization/Constants.cs
@@ -5,5 +5,11 @@ public static class Constants
     public static class Roles
     {
         public const string ADMINISTRATORS = "Administrators";
+        public const string PRODUCT_MANAGERS = "Product Managers";
+    }
+
+    public static class RoleCombinations
+    {
+        public const string ADMIN_PORTAL_ROLES = $"{Roles.ADMINISTRATORS},{Roles.PRODUCT_MANAGERS}";
     }
 }

--- a/src/Infrastructure/Identity/AppIdentityDbContextSeed.cs
+++ b/src/Infrastructure/Identity/AppIdentityDbContextSeed.cs
@@ -16,9 +16,18 @@ public class AppIdentityDbContextSeed
         }
 
         await roleManager.CreateAsync(new IdentityRole(BlazorShared.Authorization.Constants.Roles.ADMINISTRATORS));
+        await roleManager.CreateAsync(new IdentityRole(BlazorShared.Authorization.Constants.Roles.PRODUCT_MANAGERS));
 
         var defaultUser = new ApplicationUser { UserName = "demouser@microsoft.com", Email = "demouser@microsoft.com" };
         await userManager.CreateAsync(defaultUser, AuthorizationConstants.DEFAULT_PASSWORD);
+
+        var productManager = new ApplicationUser { UserName = "productmgr@microsoft.com", Email = "productmgr@microsoft.com" };
+        await userManager.CreateAsync(productManager, AuthorizationConstants.DEFAULT_PASSWORD);
+        productManager = await userManager.FindByNameAsync(productManager.UserName);
+        if (productManager != null)
+        {
+            await userManager.AddToRoleAsync(productManager, BlazorShared.Authorization.Constants.Roles.PRODUCT_MANAGERS);
+        }
 
         string adminUserName = "admin@microsoft.com";
         var adminUser = new ApplicationUser { UserName = adminUserName, Email = adminUserName };

--- a/src/PublicApi/CatalogItemEndpoints/CreateCatalogItemEndpoint.cs
+++ b/src/PublicApi/CatalogItemEndpoints/CreateCatalogItemEndpoint.cs
@@ -19,7 +19,7 @@ public class CreateCatalogItemEndpoint(IRepository<CatalogItem> itemRepository, 
     public override void Configure()
     {
         Post("api/catalog-items");
-        Roles(BlazorShared.Authorization.Constants.Roles.ADMINISTRATORS);
+        Roles(BlazorShared.Authorization.Constants.Roles.PRODUCT_MANAGERS);
         AuthSchemes(JwtBearerDefaults.AuthenticationScheme);
         Description(d =>
             d.Produces<CreateCatalogItemResponse>()

--- a/src/PublicApi/CatalogItemEndpoints/DeleteCatalogItemEndpoint.cs
+++ b/src/PublicApi/CatalogItemEndpoints/DeleteCatalogItemEndpoint.cs
@@ -17,7 +17,7 @@ public class DeleteCatalogItemEndpoint(IRepository<CatalogItem> itemRepository) 
     public override void Configure()
     {
         Delete("api/catalog-items/{catalogItemId}");
-        Roles(BlazorShared.Authorization.Constants.Roles.ADMINISTRATORS);
+        Roles(BlazorShared.Authorization.Constants.Roles.PRODUCT_MANAGERS);
         AuthSchemes(JwtBearerDefaults.AuthenticationScheme);
         Description(d =>
             d.Produces<DeleteCatalogItemResponse>()

--- a/src/PublicApi/CatalogItemEndpoints/UpdateCatalogItemEndpoint.cs
+++ b/src/PublicApi/CatalogItemEndpoints/UpdateCatalogItemEndpoint.cs
@@ -18,7 +18,7 @@ public class UpdateCatalogItemEndpoint(IRepository<CatalogItem> itemRepository, 
     public override void Configure()
     {
         Put("api/catalog-items");
-        Roles(BlazorShared.Authorization.Constants.Roles.ADMINISTRATORS);
+        Roles(BlazorShared.Authorization.Constants.Roles.PRODUCT_MANAGERS);
         AuthSchemes(JwtBearerDefaults.AuthenticationScheme);
         Description(d =>
             d.Produces<UpdateCatalogItemResponse>()

--- a/src/Web/Views/Shared/_LoginPartial.cshtml
+++ b/src/Web/Views/Shared/_LoginPartial.cshtml
@@ -8,7 +8,8 @@
                     <img class="esh-identity-image" src="~/images/arrow-down.png">
                 </section>
                 <section class="esh-identity-drop">
-                    @if (User.IsInRole("Administrators"))
+                    @if (User.IsInRole(BlazorShared.Authorization.Constants.Roles.ADMINISTRATORS) 
+                        || User.IsInRole(BlazorShared.Authorization.Constants.Roles.PRODUCT_MANAGERS))
                     {
                         <a class="esh-identity-item"
                            asp-page="/Admin/Index">

--- a/tests/PublicApiIntegrationTests/ApiTokenHelper.cs
+++ b/tests/PublicApiIntegrationTests/ApiTokenHelper.cs
@@ -18,6 +18,14 @@ namespace PublicApiIntegrationTests
             return CreateToken(userName, roles);
         }
 
+        public static string GetProductManagerUserToken()
+        {
+            string userName = "productmgr@microsoft.com";
+            string[] roles = { "Product Managers" };
+
+            return CreateToken(userName, roles);
+        }
+
         public static string GetNormalUserToken()
         {
             string userName = "demouser@microsoft.com";

--- a/tests/PublicApiIntegrationTests/CatalogItemEndpoints/CreateCatalogItemEndpointTest.cs
+++ b/tests/PublicApiIntegrationTests/CatalogItemEndpoints/CreateCatalogItemEndpointTest.cs
@@ -33,10 +33,10 @@ public class CreateCatalogItemEndpointTest
     }
 
     [TestMethod]
-    public async Task ReturnsSuccessGivenValidNewItemAndAdminUserToken()
+    public async Task ReturnsSuccessGivenValidNewItemAndProductManagerUserToken()
     {
         var jsonContent = GetValidNewItemJson();
-        var adminToken = ApiTokenHelper.GetAdminUserToken();
+        var adminToken = ApiTokenHelper.GetProductManagerUserToken();
         var client = ProgramTest.NewClient;
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
         var response = await client.PostAsync("api/catalog-items", jsonContent);

--- a/tests/PublicApiIntegrationTests/CatalogItemEndpoints/CreateCatalogItemEndpointTest.cs
+++ b/tests/PublicApiIntegrationTests/CatalogItemEndpoints/CreateCatalogItemEndpointTest.cs
@@ -21,10 +21,23 @@ public class CreateCatalogItemEndpointTest
 
 
     [TestMethod]
-    public async Task ReturnsNotAuthorizedGivenNormalUserToken()
+    public async Task ReturnsForbiddenGivenNormalUserToken()
     {
         var jsonContent = GetValidNewItemJson();
         var token = ApiTokenHelper.GetNormalUserToken();
+        var client = ProgramTest.NewClient;
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        var response = await client.PostAsync("api/catalog-items", jsonContent);
+
+        Assert.AreEqual(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+
+    [TestMethod]
+    public async Task ReturnsForbiddenGivenAdminUserToken()
+    {
+        var jsonContent = GetValidNewItemJson();
+        var token = ApiTokenHelper.GetAdminUserToken();
         var client = ProgramTest.NewClient;
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", token);
         var response = await client.PostAsync("api/catalog-items", jsonContent);

--- a/tests/PublicApiIntegrationTests/CatalogItemEndpoints/DeleteCatalogItemEndpointTest.cs
+++ b/tests/PublicApiIntegrationTests/CatalogItemEndpoints/DeleteCatalogItemEndpointTest.cs
@@ -11,9 +11,9 @@ namespace PublicApiIntegrationTests.CatalogItemEndpoints;
 public class DeleteCatalogItemEndpointTest
 {
     [TestMethod]
-    public async Task ReturnsSuccessGivenValidIdAndAdminUserToken()
+    public async Task ReturnsSuccessGivenValidIdAndProductManagerUserToken()
     {
-        var adminToken = ApiTokenHelper.GetAdminUserToken();
+        var adminToken = ApiTokenHelper.GetProductManagerUserToken();
         var client = ProgramTest.NewClient;
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
         var response = await client.DeleteAsync("api/catalog-items/12");
@@ -25,9 +25,9 @@ public class DeleteCatalogItemEndpointTest
     }
 
     [TestMethod]
-    public async Task ReturnsNotFoundGivenInvalidIdAndAdminUserToken()
+    public async Task ReturnsNotFoundGivenInvalidIdAndProductManagerUserToken()
     {
-        var adminToken = ApiTokenHelper.GetAdminUserToken();
+        var adminToken = ApiTokenHelper.GetProductManagerUserToken();
         var client = ProgramTest.NewClient;
         client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken);
         var response = await client.DeleteAsync("api/catalog-items/0");


### PR DESCRIPTION
- This allows us to set up for the use cases:
  - ADMINISTRATORS can manage roles (eventually - with #182 )
  - PRODUCT MANAGERS can do the full CRUD for product management
  
  This PR:
  - Adds a role for PRODUCT MANAGERS
  - Adds a RoleCombination so that we can have multiple roles access the Admin portal
  - Adds a product manager to the seed data