### PR TITLE
Removing Microsoft.AspNetCore.Identity reference

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -30,7 +30,6 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.2" PrivateAssets="all" />
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.2" />
-    <PackageVersion Include="Microsoft.AspNetCore.Identity" Version="2.3.1" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.2" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.UI" Version="9.0.2" />
     <PackageVersion Include="Microsoft.Extensions.Identity.Stores" Version="9.0.2" />

--- a/src/BlazorAdmin/BlazorAdmin.csproj
+++ b/src/BlazorAdmin/BlazorAdmin.csproj
@@ -6,7 +6,6 @@
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" />		
 		<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" />		
-		<PackageReference Include="Microsoft.AspNetCore.Identity" />
 		<PackageReference Include="Microsoft.Extensions.Identity.Core" />
 		<PackageReference Include="Microsoft.Extensions.Identity.Stores" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Configuration" />


### PR DESCRIPTION
- Removing reference to unused package
- The `Microsoft.AspNetCore.Identity` namespace is in newer packages.