### PR TITLE
User Management Updates

### DIFF
--- a/src/ApplicationCore/Exceptions/AdminProtectionException.cs
+++ b/src/ApplicationCore/Exceptions/AdminProtectionException.cs
@@ -1,9 +1,0 @@
-﻿using System;
-
-namespace Microsoft.eShopWeb.ApplicationCore.Exceptions;
-public class AdminProtectionException : Exception
-{
-    public AdminProtectionException() : base($"The admin account cannot be deleted at this time.")
-    {
-    }
-}

--- a/src/BlazorAdmin/Interfaces/IUserManagementService.cs
+++ b/src/BlazorAdmin/Interfaces/IUserManagementService.cs
@@ -1,14 +1,12 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 using BlazorAdmin.Models;
-using BlazorAdmin.Pages.CatalogItemPage;
 
 namespace BlazorAdmin.Interfaces;
 
 public interface IUserManagementService
 {
     Task<CreateUserResponse> Create(CreateUserRequest user);
-    Task<GetUserResponse> Edit(GetUserResponse user);
+    Task<GetUserResponse> Update(UpdateUserRequest user);
     Task Delete(string id);
     Task<GetUserResponse> GetById(string id);
     Task<GetUserResponse> GetByName(string userName);

--- a/src/BlazorAdmin/Models/GetUserResponse.cs
+++ b/src/BlazorAdmin/Models/GetUserResponse.cs
@@ -1,10 +1,8 @@
-﻿using Microsoft.eShopWeb.Infrastructure.Identity;
-
-namespace BlazorAdmin.Models;
+﻿namespace BlazorAdmin.Models;
 
 public class GetUserResponse
 {
-    public ApplicationUser User { get; set; }
+    public User User { get; set; }
 
     public GetUserResponse()
     {

--- a/src/BlazorAdmin/Models/UpdateUserRequest.cs
+++ b/src/BlazorAdmin/Models/UpdateUserRequest.cs
@@ -1,10 +1,10 @@
 ﻿namespace BlazorAdmin.Models;
 
-public class CreateUserRequest
+public class UpdateUserRequest
 {
     public User User{  get; set; }
 
-    public CreateUserRequest()
+    public UpdateUserRequest()
     {
         User = new();
     }

--- a/src/BlazorAdmin/Models/User.cs
+++ b/src/BlazorAdmin/Models/User.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace BlazorAdmin.Models;
+
+public class User()
+{
+    public string Id { get; set; }
+    public string UserName { get; set; }
+    public string Email { get; set; }
+    public bool EmailConfirmed { get; set; }
+    public string PhoneNumber { get; set; }
+    public bool PhoneNumberConfirmed { get; set; }
+    public bool TwoFactorEnabled { get; set; }
+    public DateTimeOffset? LockoutEnd { get; set; }
+}

--- a/src/BlazorAdmin/Models/UserListResponse.cs
+++ b/src/BlazorAdmin/Models/UserListResponse.cs
@@ -1,9 +1,8 @@
 ﻿using System.Collections.Generic;
-using Microsoft.eShopWeb.Infrastructure.Identity;
 
 namespace BlazorAdmin.Models;
 
 public class UserListResponse
 {
-    public List<ApplicationUser> Users { get; set; } = [];
+    public List<User> Users { get; set; } = [];
 }

--- a/src/BlazorAdmin/Pages/UserPage/Create.razor
+++ b/src/BlazorAdmin/Pages/UserPage/Create.razor
@@ -137,9 +137,9 @@
         {
             var result = await UserManagementService.Create(_item);
             var checkedRoles = _selectedRoles.Where(r => r.Value).Select(r => r.Key).ToList();
-            if (checkedRoles.Any()){
+            if (checkedRoles.Count > 0){
                 SaveRolesForUserRequest rolesForUserRequest = new SaveRolesForUserRequest(){
-                    UserId = _item.User.Id,
+                    UserId = result.User.Id,
                     RolesToAdd = checkedRoles
                 };
 

--- a/src/BlazorAdmin/Pages/UserPage/Edit.razor
+++ b/src/BlazorAdmin/Pages/UserPage/Edit.razor
@@ -9,6 +9,7 @@
 @using BlazorAdmin.Interfaces
 @using BlazorAdmin.Models
 @using Microsoft.AspNetCore.Identity
+@using Microsoft.eShopWeb.ApplicationCore.Entities
 @using Microsoft.eShopWeb.Infrastructure.Identity
 
 <div class="modal @_modalClass" tabindex="-1" role="dialog" style="display:@_modalDisplay">
@@ -20,9 +21,9 @@
             }
             else
             {
-                <EditForm Model="_item.User" OnValidSubmit="@SaveClick">
+                <EditForm Model="_item" OnValidSubmit="@SaveClick">
                     <div class="modal-header">
-                        <h5 class="modal-title" id="exampleModalLabel">Edit @_item.User.UserName</h5>
+                        <h5 class="modal-title" id="exampleModalLabel">Edit @_item.UserName</h5>
                         <button type="button" class="close" data-dismiss="modal" aria-label="Close" @onclick="Close">
                             <span aria-hidden="true">&times;</span>
                         </button>
@@ -35,45 +36,45 @@
                                     <div class="form-group row">
                                         <label for="UserName" class="control-label col-md-6">Username</label>
                                         <div class="col-md-6">
-                                            <InputText id="UserName" class="form-control" @bind-Value="_item.User.UserName" />
-                                            <ValidationMessage For="@(() => _item.User.UserName)" class="text-danger" />
+                                            <InputText id="UserName" class="form-control" @bind-Value="_item.UserName" />
+                                            <ValidationMessage For="@(() => _item.UserName)" class="text-danger" />
                                         </div>
                                     </div>
 
                                     <div class="form-group row">
                                         <label for="Email" class="control-label col-md-6">Email</label>
                                         <div class="col-md-6">
-                                            <InputText id="Email" class="form-control" @bind-Value="_item.User.Email" />
-                                            <ValidationMessage For="@(() => _item.User.Email)" class="text-danger" />
+                                            <InputText id="Email" class="form-control" @bind-Value="_item.Email" />
+                                            <ValidationMessage For="@(() => _item.Email)" class="text-danger" />
                                         </div>
                                     </div>
 
                                     <div class="form-group row">
                                         <label for="PhoneNumber" class="control-label col-md-6">Phone Number</label>
                                         <div class="col-md-6">
-                                            <InputText id="PhoneNumber" class="form-control" @bind-Value="_item.User.PhoneNumber" />
-                                            <ValidationMessage For="@(() => _item.User.PhoneNumber)" class="text-danger" />
+                                            <InputText id="PhoneNumber" class="form-control" @bind-Value="_item.PhoneNumber" />
+                                            <ValidationMessage For="@(() => _item.PhoneNumber)" class="text-danger" />
                                         </div>
                                     </div>
 
                                     <div class="form-group row form-check">
                                         <div class="col-md-6">
-                                            <InputCheckbox id="EmailConfirmed" class="form-check-input" @bind-Value="_item.User.EmailConfirmed" />
+                                            <InputCheckbox id="EmailConfirmed" class="form-check-input" @bind-Value="_item.EmailConfirmed" />
                                             <label for="EmailConfirmed" class="form-check-label">Email Confirmed</label>
                                         </div>
                                     </div>
 
                                     <div class="form-group row form-check">
                                         <div class="col-md-6">
-                                            <InputCheckbox id="TwoFactorEnabled" class="form-check-input" @bind-Value="_item.User.TwoFactorEnabled" />
+                                            <InputCheckbox id="TwoFactorEnabled" class="form-check-input" @bind-Value="_item.TwoFactorEnabled" />
                                             <label for="TwoFactorEnabled" class="form-check-label">Two-Factor Authentication Enabled</label>
                                         </div>
                                     </div>
                                     <div class="form-group row">
                                         <label for="LockoutEnd" class="control-label col-md-6">Lockout Until</label>
                                         <div class="col-md-6">
-                                            <InputDate id="LockoutEnd" class="form-control" @bind-Value="_item.User.LockoutEnd" />
-                                            <ValidationMessage For="@(() => _item.User.LockoutEnd)" class="text-danger" />
+                                            <InputDate id="LockoutEnd" class="form-control" @bind-Value="_item.LockoutEnd" />
+                                            <ValidationMessage For="@(() => _item.LockoutEnd)" class="text-danger" />
                                         </div>
                                     </div>
                                 </div>
@@ -118,13 +119,16 @@
 }
 
 @code {
+
+
+
     [Parameter]
     public EventCallback<string> OnSaveClick { get; set; }
 
     private string _modalDisplay = "none;";
     private string _modalClass = "";
     private bool _showEditModal = false;
-    private GetUserResponse _item = new GetUserResponse();
+    private User _item = new User();
 
     private Dictionary<string, bool> _selectedRoles = new();
     private Dictionary<string, bool> _startingRoles = new();
@@ -132,7 +136,13 @@
 
     private async Task SaveClick()
     {
-        await UserManagementService.Edit(_item);
+
+        var updateRequest = new UpdateUserRequest()
+        {
+            User = _item
+        };
+
+        await UserManagementService.Update(updateRequest);
 
         var checkedRoles = _selectedRoles.Where(r => r.Value).Select(r => r.Key).ToList();
         var startingRoles = _startingRoles.Where(r => r.Value).Select(r => r.Key).ToList();
@@ -145,7 +155,7 @@
             Logger.LogInformation("Total number of roles to remove: {removedRolesCount}", rolesToRemove.Count);
 
             SaveRolesForUserRequest rolesForUserRequest = new SaveRolesForUserRequest(){
-                UserId = _item.User.Id,
+                UserId = _item.Id,
                 RolesToAdd = rolesToAdd, 
                 RolesToRemove = rolesToRemove
             };
@@ -153,7 +163,7 @@
             await UserManagementService.SaveRolesForUser(rolesForUserRequest);
         }
 
-        Logger.LogInformation("Updated User Id: {userId}", _item.User.Id);
+        Logger.LogInformation("Updated User Id: {userId}", _item.Id);
         await OnSaveClick.InvokeAsync(null);
         await Close();
     }
@@ -164,7 +174,7 @@
 
         await new Css(JSRuntime).HideBodyOverflow();
 
-        _item = await UserManagementService.GetById(id);
+        _item = (await UserManagementService.GetById(id)).User;
         _roles = (await RoleManagementService.List()).Roles;
         var userRoles = await UserManagementService.GetRolesByUserId(id);
         foreach (var role in _roles)
@@ -175,7 +185,7 @@
             _startingRoles[role.Name] = checkedStatus;
         }
 
-        Logger.LogInformation("Acquired user {id}",_item.User.Id);
+        Logger.LogInformation("Acquired user {id}",_item.Id);
 
         Logger.LogInformation("Total Roles assigned: {roleCount}", userRoles.Roles.Count);
 

--- a/src/BlazorAdmin/Pages/UserPage/List.razor.cs
+++ b/src/BlazorAdmin/Pages/UserPage/List.razor.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using BlazorAdmin.Helpers;
 using BlazorAdmin.Interfaces;
-using Microsoft.eShopWeb.Infrastructure.Identity;
+using BlazorAdmin.Models;
 using Microsoft.Extensions.Logging;
 
 namespace BlazorAdmin.Pages.UserPage;
@@ -14,7 +14,7 @@ public partial class List : BlazorComponent
     [Microsoft.AspNetCore.Components.Inject]
     ILogger<List> Logger { get; set; }
 
-    private List<ApplicationUser> _users = [];
+    private List<User> _users = [];
     private Create CreateComponent { get; set; }
     private Delete DeleteComponent { get; set; }
     private Edit EditComponent { get; set; }
@@ -31,7 +31,6 @@ public partial class List : BlazorComponent
 
         await base.OnAfterRenderAsync(firstRender);
     }
-
 
     private async Task CreateClick()
     {

--- a/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
+++ b/src/BlazorAdmin/Services/CachedCatalogItemServiceDecorator.cs
@@ -13,7 +13,7 @@ public class CachedCatalogItemServiceDecorator : ICatalogItemService
 {
     private readonly ILocalStorageService _localStorageService;
     private readonly CatalogItemService _catalogItemService;
-    private ILogger<CachedCatalogItemServiceDecorator> _logger;
+    private readonly ILogger<CachedCatalogItemServiceDecorator> _logger;
 
     public CachedCatalogItemServiceDecorator(ILocalStorageService localStorageService,
         CatalogItemService catalogItemService,

--- a/src/BlazorAdmin/Services/CachedCatalogLookupDataServiceDecorator .cs
+++ b/src/BlazorAdmin/Services/CachedCatalogLookupDataServiceDecorator .cs
@@ -15,7 +15,7 @@ public class CachedCatalogLookupDataServiceDecorator<TLookupData, TReponse>
 {
     private readonly ILocalStorageService _localStorageService;
     private readonly CatalogLookupDataService<TLookupData, TReponse> _catalogTypeService;
-    private ILogger<CachedCatalogLookupDataServiceDecorator<TLookupData, TReponse>> _logger;
+    private readonly ILogger<CachedCatalogLookupDataServiceDecorator<TLookupData, TReponse>> _logger;
 
     public CachedCatalogLookupDataServiceDecorator(ILocalStorageService localStorageService,
         CatalogLookupDataService<TLookupData, TReponse> catalogTypeService,

--- a/src/BlazorAdmin/Services/UserManagementService.cs
+++ b/src/BlazorAdmin/Services/UserManagementService.cs
@@ -18,7 +18,7 @@ public class UserManagementService(HttpService httpService, ILogger<IUserManagem
         await httpService.HttpDelete($"users/{userId}");
     }
 
-    public async Task<GetUserResponse> Edit(GetUserResponse user)
+    public async Task<GetUserResponse> Update(UpdateUserRequest user)
     {
         return await httpService.HttpPut<GetUserResponse>($"users", user);
     }

--- a/src/PublicApi/Extensions/ApplicationUserExtensions.cs
+++ b/src/PublicApi/Extensions/ApplicationUserExtensions.cs
@@ -1,26 +1,40 @@
-﻿using System;
-using System.Linq;
-using System.Reflection;
-using Microsoft.eShopWeb.Infrastructure.Identity;
+﻿using Microsoft.eShopWeb.Infrastructure.Identity;
+using Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 
 namespace Microsoft.eShopWeb.PublicApi.Extensions;
 
 public static class ApplicationUserExtensions
 {
-    public static void CopyProperties(this ApplicationUser trackedInstance, ApplicationUser updatedInstance)
+    public static UserDto ToUserDto(this ApplicationUser user)
     {
-        // Copy all properties over except Id.
-        // Id is the primary key and is used by EF Core for identifying the instance.
-        if (trackedInstance == null || updatedInstance == null)
-            throw new ArgumentNullException("The tracked instance and the updated values instance cannot be null");
-
-        var properties = trackedInstance.GetType().GetProperties(BindingFlags.Public | BindingFlags.Instance)
-                                  .Where(p => p.CanWrite && p.Name != "Id");
-
-        foreach (var prop in properties)
+        UserDto dto = new UserDto();
+        if (user != null)
         {
-            var updatedValue = prop.GetValue(updatedInstance);
-            prop.SetValue(trackedInstance, updatedValue);
+            dto.Id = user.Id;
+            dto.UserName = user.UserName;
+            dto.Email = user.Email;
+            dto.PhoneNumber = user.PhoneNumber;
+            dto.EmailConfirmed = user.EmailConfirmed;
+            dto.PhoneNumberConfirmed = user.PhoneNumberConfirmed;
+            dto.LockoutEnd = user.LockoutEnd;
+
+        }
+        return dto;
+    }
+
+    public static void FromUserDto(this ApplicationUser user, UserDto userChanges, bool copyId = true)
+    {        
+        if (user != null)
+        {
+            if (copyId)
+                user.Id = userChanges.Id;
+            user.UserName = userChanges.UserName;
+            user.Email = userChanges.Email;
+            user.PhoneNumber = userChanges.PhoneNumber;
+            user.EmailConfirmed = userChanges.EmailConfirmed;
+            user.PhoneNumberConfirmed = userChanges.PhoneNumberConfirmed;
+            user.LockoutEnd = userChanges.LockoutEnd;
+
         }
     }
 }

--- a/src/PublicApi/Middleware/ExceptionMiddleware.cs
+++ b/src/PublicApi/Middleware/ExceptionMiddleware.cs
@@ -41,15 +41,6 @@ public class ExceptionMiddleware
                 Message = exception.Message
             }.ToString());
         }
-        else if (exception is AdminProtectionException)
-        {
-            context.Response.StatusCode = (int)HttpStatusCode.Forbidden;
-            await context.Response.WriteAsync(new ErrorDetails()
-            {
-                StatusCode = context.Response.StatusCode,
-                Message = exception.Message
-            }.ToString());
-        }
         else
         {
             context.Response.StatusCode = (int)HttpStatusCode.InternalServerError;

--- a/src/PublicApi/UserManagementEndpoints/CreateUserEndpoint.CreateUserRequest.cs
+++ b/src/PublicApi/UserManagementEndpoints/CreateUserEndpoint.CreateUserRequest.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.eShopWeb.Infrastructure.Identity;
-
-namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
+﻿namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 
 public class CreateUserRequest : BaseRequest
 {
-    public ApplicationUser User { get; set; }
+    public UserDto User { get; set; }
 }

--- a/src/PublicApi/UserManagementEndpoints/CreateUserEndpoint.CreateUserResponse.cs
+++ b/src/PublicApi/UserManagementEndpoints/CreateUserEndpoint.CreateUserResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.eShopWeb.Infrastructure.Identity;
 
 namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 
@@ -11,5 +10,5 @@ public class CreateUserResponse : BaseResponse
     }
     public CreateUserResponse() { }
 
-    public ApplicationUser User { get; set; }
+    public UserDto User { get; set; }
 }

--- a/src/PublicApi/UserManagementEndpoints/Models/GetUserResponse.cs
+++ b/src/PublicApi/UserManagementEndpoints/Models/GetUserResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Microsoft.eShopWeb.Infrastructure.Identity;
 
 namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints.Models;
 
@@ -14,5 +13,5 @@ public class GetUserResponse : BaseResponse
     {
     }
 
-    public ApplicationUser User { get; set; }
+    public UserDto User { get; set; }
 }

--- a/src/PublicApi/UserManagementEndpoints/SaveRolesForUserEndpoint.cs
+++ b/src/PublicApi/UserManagementEndpoints/SaveRolesForUserEndpoint.cs
@@ -11,7 +11,7 @@ using Microsoft.eShopWeb.Infrastructure.Identity;
 
 namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 
-public class SaveRolesForUserEndpoint(UserManager<ApplicationUser> userManager) : Endpoint<SaveRolesForUserRequest, Results<Ok, NotFound>>
+public class SaveRolesForUserEndpoint(UserManager<ApplicationUser> userManager) : Endpoint<SaveRolesForUserRequest, Results<Ok, NotFound, BadRequest>>
 {
     public override void Configure()
     {
@@ -28,7 +28,7 @@ public class SaveRolesForUserEndpoint(UserManager<ApplicationUser> userManager) 
         );
     }
 
-    public override async Task<Results<Ok, NotFound>> ExecuteAsync(SaveRolesForUserRequest request, CancellationToken ct)
+    public override async Task<Results<Ok, NotFound, BadRequest>> ExecuteAsync(SaveRolesForUserRequest request, CancellationToken ct)
     {
         var userToUpdate = await userManager.FindByIdAsync(request.UserId);
         if (userToUpdate is null)
@@ -42,12 +42,12 @@ public class SaveRolesForUserEndpoint(UserManager<ApplicationUser> userManager) 
         }
         if (userToUpdate.UserName == "admin@microsoft.com")
         {
-            throw new AdminProtectionException();
+            return TypedResults.BadRequest();
         }
 
-        if (request.RolesToAdd.Any())
+        if (request.RolesToAdd.Count > 0)
             await userManager.AddToRolesAsync(userToUpdate,request.RolesToAdd);
-        if (request.RolesToRemove.Any())
+        if (request.RolesToRemove.Count > 0)
             await userManager.RemoveFromRolesAsync(userToUpdate,request.RolesToRemove);
 
         return TypedResults.Ok();

--- a/src/PublicApi/UserManagementEndpoints/UpdateUserEndpoint.UpdateUserRequest.cs
+++ b/src/PublicApi/UserManagementEndpoints/UpdateUserEndpoint.UpdateUserRequest.cs
@@ -1,8 +1,6 @@
-﻿using Microsoft.eShopWeb.Infrastructure.Identity;
-
-namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
+﻿namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 
 public class UpdateUserRequest : BaseRequest
 {
-    public ApplicationUser User { get; set; }
+    public UserDto User { get; set; }
 }

--- a/src/PublicApi/UserManagementEndpoints/UpdateUserEndpoint.cs
+++ b/src/PublicApi/UserManagementEndpoints/UpdateUserEndpoint.cs
@@ -26,7 +26,7 @@ public class UpdateRoleEndpoint(UserManager<ApplicationUser> userManager) : Endp
     {
         var response = new UpdateUserResponse(request.CorrelationId());
 
-        if (request is null || request.User is null)
+        if (request is null || request.User is null || request.User.Id is null)
         {
             return TypedResults.NotFound();
         }
@@ -36,11 +36,10 @@ public class UpdateRoleEndpoint(UserManager<ApplicationUser> userManager) : Endp
         {
             return TypedResults.NotFound();
         }
-        // TODO: Update most fields - not the full entity
-        // This is due to EFCore Tracking
-        existingUser.CopyProperties(request.User);
-        
-        await userManager.UpdateAsync(existingUser);
+
+        existingUser.FromUserDto(request.User);
+
+        var updateResponse = await userManager.UpdateAsync(existingUser);
         response.User = (await userManager.FindByIdAsync(existingUser.Id))!;
         return TypedResults.Ok(response);
     }

--- a/src/PublicApi/UserManagementEndpoints/UserDto.cs
+++ b/src/PublicApi/UserManagementEndpoints/UserDto.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
+
+public class UserDto()
+{
+   public string Id {  get; set; }
+    public string? UserName { get; set; }
+    public string? Email { get; set; }
+    public bool EmailConfirmed { get; set; }
+    public string? PhoneNumber { get; set; }
+    public bool PhoneNumberConfirmed { get; set; }
+    public bool TwoFactorEnabled { get; set; }
+    public DateTimeOffset? LockoutEnd { get; set; }    
+}

--- a/src/PublicApi/UserManagementEndpoints/UserGetByIdEndpoint.cs
+++ b/src/PublicApi/UserManagementEndpoints/UserGetByIdEndpoint.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.eShopWeb.Infrastructure.Identity;
+using Microsoft.eShopWeb.PublicApi.Extensions;
 using Microsoft.eShopWeb.PublicApi.UserManagementEndpoints.Models;
 
 namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
@@ -31,8 +32,7 @@ public class UserGetByIdEndpoint (UserManager<ApplicationUser> userManager) : En
         {
             return TypedResults.NotFound();
         }
-        // TODO: Make an extension method off of Identity user to convert
-        response.User = userResponse;
+        response.User = userResponse.ToUserDto();
         return TypedResults.Ok(response);
     }
 }

--- a/src/PublicApi/UserManagementEndpoints/UserGetByUserNameEndpoint.cs
+++ b/src/PublicApi/UserManagementEndpoints/UserGetByUserNameEndpoint.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.eShopWeb.Infrastructure.Identity;
+using Microsoft.eShopWeb.PublicApi.Extensions;
 using Microsoft.eShopWeb.PublicApi.UserManagementEndpoints.Models;
 
 namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
@@ -31,8 +32,7 @@ public class UserGetByUserNameEndpoint (UserManager<ApplicationUser> userManager
         {
             return TypedResults.NotFound();
         }
-        // TODO: Make an extension method off of Identity user to convert
-        response.User = (ApplicationUser) userResponse;
+        response.User = userResponse.ToUserDto();
         return TypedResults.Ok(response);
     }
 }

--- a/src/PublicApi/UserManagementEndpoints/UserGetRolesByIdEndpoint.cs
+++ b/src/PublicApi/UserManagementEndpoints/UserGetRolesByIdEndpoint.cs
@@ -39,7 +39,7 @@ public class UserGetRolesByIdEndpoint (UserManager<ApplicationUser> userManager)
             return TypedResults.NotFound();
         }
         
-        response.Roles = rolesForUser.ToList();
+        response.Roles = [.. rolesForUser];
         return TypedResults.Ok(response);
     }
 }

--- a/src/PublicApi/UserManagementEndpoints/UserListEndpoint.UseristResponse.cs
+++ b/src/PublicApi/UserManagementEndpoints/UserListEndpoint.UseristResponse.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.eShopWeb.Infrastructure.Identity;
 
 namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 
@@ -14,5 +13,5 @@ public class UserListResponse : BaseResponse
     {
     }
 
-    public List<ApplicationUser> Users{ get; set; } = [];
+    public List<UserDto> Users{ get; set; } = [];
 }

--- a/src/PublicApi/UserManagementEndpoints/UserListEndpoint.cs
+++ b/src/PublicApi/UserManagementEndpoints/UserListEndpoint.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.eShopWeb.Infrastructure.Identity;
+using Microsoft.eShopWeb.PublicApi.Extensions;
 
 namespace Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 
@@ -25,7 +26,11 @@ public class UserListEndpoint(UserManager<ApplicationUser> userManager):Endpoint
     {
         await Task.Delay(1000, ct);
         var response = new UserListResponse();
-        response.Users = userManager.Users.ToList();
+        var users = userManager.Users.ToList();
+        foreach ( var user in users)
+        {
+            response.Users.Add(user.ToUserDto());
+        }
         return response;
     }
 }

--- a/tests/PublicApiIntegrationTests/UserManagementEndpoints/CreateUserEndpointTest.cs
+++ b/tests/PublicApiIntegrationTests/UserManagementEndpoints/CreateUserEndpointTest.cs
@@ -4,7 +4,6 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.eShopWeb;
-using Microsoft.eShopWeb.Infrastructure.Identity;
 using Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using PublicApiIntegrationTests.Helpers;
@@ -14,7 +13,7 @@ namespace PublicApiIntegrationTests.UserManagementEndpoints;
 [TestClass]
 public class CreateUserEndpointTest
 {
-    private string _testName = "test@microsoft.com";
+    private readonly string _testName = "test@microsoft.com";
 
     [TestMethod]
     public async Task ReturnsForbiddenGivenNormalUserToken()
@@ -65,12 +64,14 @@ public class CreateUserEndpointTest
 
     private StringContent GetValidNewItemJson(string userName)
     {
-        var newUser = new ApplicationUser()
+        var newUser = new UserDto()
         {
             UserName = userName
         };
-        var request = new CreateUserRequest();
-        request.User = newUser;
+        var request = new CreateUserRequest
+        {
+            User = newUser
+        };
         var jsonContent = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         return jsonContent;
@@ -78,11 +79,14 @@ public class CreateUserEndpointTest
 
     private StringContent GetInvalidNewItemJson()
     {
-        var newUser = new ApplicationUser()
+        var newUser = new UserDto()
         {
+
         };
-        var request = new CreateUserRequest();
-        request.User = newUser;
+        var request = new CreateUserRequest
+        {
+            User = newUser
+        };
         var jsonContent = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
 
         return jsonContent;

--- a/tests/PublicApiIntegrationTests/UserManagementEndpoints/DeleteUserEndpointTest.cs
+++ b/tests/PublicApiIntegrationTests/UserManagementEndpoints/DeleteUserEndpointTest.cs
@@ -41,7 +41,7 @@ public class DeleteUserEndpointTest
     }
 
     [TestMethod]
-    public async Task ReturnsForbiddenTryingToDeleteAdminUser()
+    public async Task ReturnsBadRequestTryingToDeleteAdminUser()
     {
         var client = HttpClientHelper.GetAdminClient();
         var userName = "admin@microsoft.com";
@@ -51,7 +51,7 @@ public class DeleteUserEndpointTest
         var adminUser = adminUserResponse.FromJson<Microsoft.eShopWeb.PublicApi.UserManagementEndpoints.Models.GetUserResponse>();
         var deleteResponse = await client.DeleteAsync($"api/users/{adminUser!.User!.Id}");
 
-        Assert.AreEqual(HttpStatusCode.Forbidden, deleteResponse.StatusCode);
+        Assert.AreEqual(HttpStatusCode.BadRequest, deleteResponse.StatusCode);
 
     }
 }

--- a/tests/PublicApiIntegrationTests/UserManagementEndpoints/UpdateUserEndpointTest.cs
+++ b/tests/PublicApiIntegrationTests/UserManagementEndpoints/UpdateUserEndpointTest.cs
@@ -1,0 +1,70 @@
+﻿using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.eShopWeb;
+using Microsoft.eShopWeb.PublicApi.UserManagementEndpoints;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using PublicApiIntegrationTests.Helpers;
+
+namespace PublicApiIntegrationTests.UserManagementEndpoints;
+
+[TestClass]
+public class UpdateUserEndpointTest
+{
+    [TestMethod]
+    public async Task UpdatesSuccessfullyGivenValidChangesAndAdminUserToken()
+    {
+        var client = HttpClientHelper.GetAdminClient();
+        var userName = "demouser@microsoft.com";
+
+        var response = await client.GetAsync($"api/users/name/{userName}");
+
+        var demoUserResponse = await response.Content.ReadAsStringAsync();
+        var demoUser = demoUserResponse.FromJson<Microsoft.eShopWeb.PublicApi.UserManagementEndpoints.Models.GetUserResponse>();
+
+        var startingEmailConfirmedValue = demoUser!.User.EmailConfirmed;
+        demoUser.User.EmailConfirmed = !startingEmailConfirmedValue;
+
+        UpdateUserRequest request = new UpdateUserRequest()
+        {
+            User = demoUser.User
+        };
+        var jsonContent = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
+
+        var updateResponse = await client.PutAsync("api/users", jsonContent);
+        updateResponse.EnsureSuccessStatusCode();
+        Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        
+        var updateResponseJsonString = await updateResponse.Content.ReadAsStringAsync();
+        var updatedItem = updateResponseJsonString.FromJson<UpdateUserResponse>();
+        Assert.IsNotNull(updatedItem);
+        Assert.AreEqual(!startingEmailConfirmedValue, updatedItem.User.EmailConfirmed);
+    }
+
+    [TestMethod]
+    public async Task ReturnsNotFoundForNullRequest()
+    {
+        var client = HttpClientHelper.GetAdminClient();
+
+        UpdateUserRequest request = null;
+        var jsonContent = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
+        var updateResponse = await client.PutAsync("api/users", jsonContent);
+        Assert.AreEqual(HttpStatusCode.NotFound, updateResponse.StatusCode);
+    }
+
+    [TestMethod]
+    public async Task ReturnsNotFoundForNullUserInRequest()
+    {
+        var client = HttpClientHelper.GetAdminClient();
+
+        UpdateUserRequest request = new UpdateUserRequest()
+        {
+            User = null
+        };
+        var jsonContent = new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json");
+        var updateResponse = await client.PutAsync("api/users", jsonContent);
+        Assert.AreEqual(HttpStatusCode.NotFound, updateResponse.StatusCode);
+    }
+}

--- a/tests/PublicApiIntegrationTests/UserManagementEndpoints/UserListEndpointTest.cs
+++ b/tests/PublicApiIntegrationTests/UserManagementEndpoints/UserListEndpointTest.cs
@@ -18,7 +18,6 @@ public class UserListEndpointTest
         Assert.AreEqual(HttpStatusCode.Unauthorized, response.StatusCode);        
     }
 
-
     [TestMethod]
     public async Task ReturnsForbiddenForGeneralAuthorizedAccess()
     {


### PR DESCRIPTION
- Addressing the last of the comments on #196:

- Fixed `IUserManagementService` for the Update endpoint. Not Edit. Not taking a response as a parameter.
  - Also added tests around the Update endpoint
- Refactored requests and responses to use User in BlazorAdmin and UserDto in PublicApi.
- Added ApplicationUser extension methods for converting between UserDto and it; ApplicationUser is still needed for UserManager.
  - These enabled me to remove CopyProperties.

- SaveRolesForUserEndpoint now throws Bad Request when trying to change the roles of the admin user.
