### PR TITLE
Update MSTest to 3.8.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -79,8 +79,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="MSTest.TestAdapter" Version="3.7.3" />
-    <PackageVersion Include="MSTest.TestFramework" Version="3.7.3" />
+    <PackageVersion Include="MSTest.TestAdapter" Version="3.8.3" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Seeing the dependabot failures made me look into this
- Framework also has to be updated - not just the TestAdapter 🤦🏻‍♀️