### PR TITLE
Improved PageCount calculation in the catalog items list

### DIFF
--- a/src/PublicApi/CatalogItemEndpoints/CatalogItemListPagedEndpoint.cs
+++ b/src/PublicApi/CatalogItemEndpoints/CatalogItemListPagedEndpoint.cs
@@ -51,7 +51,7 @@ public class CatalogItemListPagedEndpoint(IRepository<CatalogItem> itemRepositor
 
         if (request.PageSize > 0)
         {
-            response.PageCount = int.Parse(Math.Ceiling((decimal)totalItems / request.PageSize).ToString());
+            response.PageCount = (int) Math.Ceiling((decimal)totalItems / request.PageSize);
         }
         else
         {


### PR DESCRIPTION
This addresses #215

### Summary

Simplified the `PageCount` calculation by replacing `int.Parse(...ToString())` with a direct cast to `int`. This improves code readability and avoids unnecessary string conversion.
