### PR TITLE
Moving from xUnit v2 to v3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -70,12 +70,12 @@
     <!-- Test -->
     <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.3" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.1">
+    <PackageVersion Include="xunit.v3" Version="2.0.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>
-    <PackageVersion Include="xunit.runner.console" Version="2.9.3">
+    <PackageVersion Include="xunit.v3.runner.console" Version="2.0.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageVersion>

--- a/tests/FunctionalTests/FunctionalTests.csproj
+++ b/tests/FunctionalTests/FunctionalTests.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/FunctionalTests/Web/Controllers/AccountControllerSignIn.cs
+++ b/tests/FunctionalTests/Web/Controllers/AccountControllerSignIn.cs
@@ -21,9 +21,9 @@ public class AccountControllerSignIn : IClassFixture<TestApplication>
     [Fact]
     public async Task ReturnsSignInScreenOnGet()
     {
-        var response = await Client.GetAsync("/identity/account/login");
+        var response = await Client.GetAsync("/identity/account/login", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse = await response.Content.ReadAsStringAsync();
+        var stringResponse = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains("demouser@microsoft.com", stringResponse);
     }
@@ -45,9 +45,9 @@ public class AccountControllerSignIn : IClassFixture<TestApplication>
     [Fact]
     public async Task ReturnsFormWithRequestVerificationToken()
     {
-        var response = await Client.GetAsync("/identity/account/login");
+        var response = await Client.GetAsync("/identity/account/login", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse = await response.Content.ReadAsStringAsync();
+        var stringResponse = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         string token = WebPageHelpers.GetRequestVerificationToken(stringResponse);
         Assert.True(token.Length > 50);
@@ -56,19 +56,19 @@ public class AccountControllerSignIn : IClassFixture<TestApplication>
     [Fact]
     public async Task ReturnsSuccessfulSignInOnPostWithValidCredentials()
     {
-        var getResponse = await Client.GetAsync("/identity/account/login");
+        var getResponse = await Client.GetAsync("/identity/account/login", TestContext.Current.CancellationToken);
         getResponse.EnsureSuccessStatusCode();
-        var stringResponse1 = await getResponse.Content.ReadAsStringAsync();
+        var stringResponse1 = await getResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         var keyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("Email", "demouser@microsoft.com"),
-            new KeyValuePair<string, string>("Password", "Pass@word1"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse1))
+            new("Email", "demouser@microsoft.com"),
+            new("Password", "Pass@word1"),
+            new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse1))
         };
         var formContent = new FormUrlEncodedContent(keyValues);
 
-        var postResponse = await Client.PostAsync("/identity/account/login", formContent);
+        var postResponse = await Client.PostAsync("/identity/account/login", formContent, TestContext.Current.CancellationToken);
         Assert.Equal(HttpStatusCode.Redirect, postResponse.StatusCode);
         Assert.Equal(new System.Uri("/", UriKind.Relative), postResponse.Headers.Location);
     }
@@ -77,36 +77,36 @@ public class AccountControllerSignIn : IClassFixture<TestApplication>
     public async Task UpdatePhoneNumberProfile()
     {
         //Login
-        var getResponse = await Client.GetAsync("/identity/account/login");
+        var getResponse = await Client.GetAsync("/identity/account/login", TestContext.Current.CancellationToken);
         getResponse.EnsureSuccessStatusCode();
-        var stringResponse1 = await getResponse.Content.ReadAsStringAsync();
+        var stringResponse1 = await getResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         var keyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("Email", "demouser@microsoft.com"),
-            new KeyValuePair<string, string>("Password", "Pass@word1"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse1))
+            new("Email", "demouser@microsoft.com"),
+            new("Password", "Pass@word1"),
+            new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse1))
         };
         var formContent = new FormUrlEncodedContent(keyValues);
-        await Client.PostAsync("/identity/account/login", formContent);
+        await Client.PostAsync("/identity/account/login", formContent, TestContext.Current.CancellationToken);
 
         //Profile page
-        var profileResponse = await Client.GetAsync("/manage/my-account");
+        var profileResponse = await Client.GetAsync("/manage/my-account", TestContext.Current.CancellationToken);
         profileResponse.EnsureSuccessStatusCode();
-        var stringProfileResponse = await profileResponse.Content.ReadAsStringAsync();
+        var stringProfileResponse = await profileResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         //Update phone number
         var updateProfileValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("Email", "demouser@microsoft.com"),
-            new KeyValuePair<string, string>("PhoneNumber", "03656565"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringProfileResponse))
+            new("Email", "demouser@microsoft.com"),
+            new("PhoneNumber", "03656565"),
+            new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringProfileResponse))
         };
         var updateProfileContent = new FormUrlEncodedContent(updateProfileValues);
-        var postProfileResponse = await Client.PostAsync("/manage/my-account", updateProfileContent);
+        var postProfileResponse = await Client.PostAsync("/manage/my-account", updateProfileContent, TestContext.Current.CancellationToken);
 
         Assert.Equal(HttpStatusCode.Redirect, postProfileResponse.StatusCode);
-        var profileResponse2 = await Client.GetAsync("/manage/my-account");
-        var stringProfileResponse2 = await profileResponse2.Content.ReadAsStringAsync();
+        var profileResponse2 = await Client.GetAsync("/manage/my-account", TestContext.Current.CancellationToken);
+        var stringProfileResponse2 = await profileResponse2.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains("03656565", stringProfileResponse2);
 
     }

--- a/tests/FunctionalTests/Web/Controllers/CatalogControllerIndex.cs
+++ b/tests/FunctionalTests/Web/Controllers/CatalogControllerIndex.cs
@@ -3,22 +3,17 @@
 namespace Microsoft.eShopWeb.FunctionalTests.Web.Controllers;
 
 [Collection("Sequential")]
-public class CatalogControllerIndex : IClassFixture<TestApplication>
+public class CatalogControllerIndex(TestApplication factory) : IClassFixture<TestApplication>
 {
-    public CatalogControllerIndex(TestApplication factory)
-    {
-        Client = factory.CreateClient();
-    }
-
-    public HttpClient Client { get; }
+    public HttpClient Client { get; } = factory.CreateClient();
 
     [Fact]
     public async Task ReturnsHomePageWithProductListing()
     {
         // Arrange & Act
-        var response = await Client.GetAsync("/");
+        var response = await Client.GetAsync("/", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse = await response.Content.ReadAsStringAsync();
+        var stringResponse = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Contains(".NET Bot Black Sweatshirt", stringResponse);

--- a/tests/FunctionalTests/Web/Controllers/OrderControllerIndex.cs
+++ b/tests/FunctionalTests/Web/Controllers/OrderControllerIndex.cs
@@ -20,7 +20,7 @@ public class OrderIndexOnGet : IClassFixture<TestApplication>
     [Fact]
     public async Task ReturnsRedirectGivenAnonymousUser()
     {
-        var response = await Client.GetAsync("/order/my-orders");
+        var response = await Client.GetAsync("/order/my-orders", TestContext.Current.CancellationToken);
         var redirectLocation = response!.Headers.Location!.OriginalString;
 
         Assert.Equal(HttpStatusCode.Redirect, response.StatusCode);

--- a/tests/FunctionalTests/Web/Pages/Basket/BasketPageCheckout.cs
+++ b/tests/FunctionalTests/Web/Pages/Basket/BasketPageCheckout.cs
@@ -21,30 +21,30 @@ public class BasketPageCheckout : IClassFixture<TestApplication>
     {
 
         // Load Home Page
-        var response = await Client.GetAsync("/");
+        var response = await Client.GetAsync("/", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse1 = await response.Content.ReadAsStringAsync();
+        var stringResponse1 = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         string token = WebPageHelpers.GetRequestVerificationToken(stringResponse1);
 
         // Add Item to Cart
         var keyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("id", "2"),
-            new KeyValuePair<string, string>("name", "shirt"),
-            new KeyValuePair<string, string>("price", "19.49"),
-            new KeyValuePair<string, string>("__RequestVerificationToken", token)
+            new("id", "2"),
+            new("name", "shirt"),
+            new("price", "19.49"),
+            new("__RequestVerificationToken", token)
         };
         var formContent = new FormUrlEncodedContent(keyValues);
-        var postResponse = await Client.PostAsync("/basket/index", formContent);
+        var postResponse = await Client.PostAsync("/basket/index", formContent, TestContext.Current.CancellationToken);
         postResponse.EnsureSuccessStatusCode();
-        var stringResponse = await postResponse.Content.ReadAsStringAsync();
+        var stringResponse = await postResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains(".NET Black &amp; White Mug", stringResponse);
 
         keyValues.Clear();
 
         formContent = new FormUrlEncodedContent(keyValues);
-        var postResponse2 = await Client.PostAsync("/Basket/Checkout", formContent);
+        var postResponse2 = await Client.PostAsync("/Basket/Checkout", formContent, TestContext.Current.CancellationToken);
         Assert.Contains("/Identity/Account/Login", postResponse2!.RequestMessage!.RequestUri!.ToString()!);
     }
 }

--- a/tests/FunctionalTests/Web/Pages/Basket/CheckoutTest.cs
+++ b/tests/FunctionalTests/Web/Pages/Basket/CheckoutTest.cs
@@ -21,46 +21,46 @@ public class CheckoutTest : IClassFixture<TestApplication>
     {
 
         // Load Home Page
-        var response = await Client.GetAsync("/");
+        var response = await Client.GetAsync("/", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse = await response.Content.ReadAsStringAsync();
+        var stringResponse = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         // Add Item to Cart
         var keyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("id", "2"),
-            new KeyValuePair<string, string>("name", "shirt"),
-            new KeyValuePair<string, string>("price", "19.49"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse))
+           new("id", "2"),
+           new("name", "shirt"),
+           new("price", "19.49"),
+           new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse))
         };
         var formContent = new FormUrlEncodedContent(keyValues);
-        var postResponse = await Client.PostAsync("/basket/index", formContent);
+        var postResponse = await Client.PostAsync("/basket/index", formContent, TestContext.Current.CancellationToken);
         postResponse.EnsureSuccessStatusCode();
-        var stringPostResponse = await postResponse.Content.ReadAsStringAsync();
+        var stringPostResponse = await postResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains(".NET Black &amp; White Mug", stringPostResponse);
 
         //Load login page
-        var loginResponse = await Client.GetAsync("/Identity/Account/Login");
+        var loginResponse = await Client.GetAsync("/Identity/Account/Login", TestContext.Current.CancellationToken);
         var longinKeyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("email", "demouser@microsoft.com"),
-            new KeyValuePair<string, string>("password", "Pass@word1"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(await loginResponse.Content.ReadAsStringAsync()))
+           new("email", "demouser@microsoft.com"),
+           new("password", "Pass@word1"),
+           new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(await loginResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken)))
         };
         var loginFormContent = new FormUrlEncodedContent(longinKeyValues);
-        var loginPostResponse = await Client.PostAsync("/Identity/Account/Login?ReturnUrl=%2FBasket%2FCheckout", loginFormContent);
-        var loginStringResponse = await loginPostResponse.Content.ReadAsStringAsync();
+        var loginPostResponse = await Client.PostAsync("/Identity/Account/Login?ReturnUrl=%2FBasket%2FCheckout", loginFormContent, TestContext.Current.CancellationToken);
+        var loginStringResponse = await loginPostResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         //Basket checkout (Pay now)
         var checkOutKeyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("Items[0].Id", "2"),
-            new KeyValuePair<string, string>("Items[0].Quantity", "1"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(loginStringResponse))
+           new("Items[0].Id", "2"),
+           new("Items[0].Quantity", "1"),
+           new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(loginStringResponse))
         };
         var checkOutContent = new FormUrlEncodedContent(checkOutKeyValues);     
-        var checkOutResponse = await Client.PostAsync("/basket/checkout", checkOutContent);
-        var stringCheckOutResponse = await checkOutResponse.Content.ReadAsStringAsync();
+        var checkOutResponse = await Client.PostAsync("/basket/checkout", checkOutContent, TestContext.Current.CancellationToken);
+        var stringCheckOutResponse = await checkOutResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains("/Basket/Success", checkOutResponse.RequestMessage!.RequestUri!.ToString());
         Assert.Contains("Thanks for your Order!", stringCheckOutResponse);

--- a/tests/FunctionalTests/Web/Pages/Basket/IndexTest.cs
+++ b/tests/FunctionalTests/Web/Pages/Basket/IndexTest.cs
@@ -21,36 +21,36 @@ public class IndexTest : IClassFixture<TestApplication>
     public async Task OnPostUpdateTo50Successfully()
     {
         // Load Home Page
-        var response = await Client.GetAsync("/");
+        var response = await Client.GetAsync("/", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse1 = await response.Content.ReadAsStringAsync();
+        var stringResponse1 = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         string token = WebPageHelpers.GetRequestVerificationToken(stringResponse1);
 
         // Add Item to Cart
         var keyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("id", "2"),
-            new KeyValuePair<string, string>("name", "shirt"),
-            new KeyValuePair<string, string>("__RequestVerificationToken", token)
+           new("id", "2"),
+           new("name", "shirt"),
+           new("__RequestVerificationToken", token)
         };
         var formContent = new FormUrlEncodedContent(keyValues);
-        var postResponse = await Client.PostAsync("/basket/index", formContent);
+        var postResponse = await Client.PostAsync("/basket/index", formContent, TestContext.Current.CancellationToken);
         postResponse.EnsureSuccessStatusCode();
-        var stringResponse = await postResponse.Content.ReadAsStringAsync();
+        var stringResponse = await postResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains(".NET Black &amp; White Mug", stringResponse);
 
         //Update
         var updateKeyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("Items[0].Id", WebPageHelpers.GetId(stringResponse)),
-            new KeyValuePair<string, string>("Items[0].Quantity", "49"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse))
+           new("Items[0].Id", WebPageHelpers.GetId(stringResponse)),
+           new("Items[0].Quantity", "49"),
+           new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse))
         };
         var updateContent = new FormUrlEncodedContent(updateKeyValues);
-        var updateResponse = await Client.PostAsync("/basket/update", updateContent);
+        var updateResponse = await Client.PostAsync("/basket/update", updateContent, TestContext.Current.CancellationToken);
 
-        var stringUpdateResponse = await updateResponse.Content.ReadAsStringAsync();
+        var stringUpdateResponse = await updateResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains("/basket/update", updateResponse!.RequestMessage!.RequestUri!.ToString()!);
         decimal expectedTotalAmount = 416.50M;
@@ -61,36 +61,36 @@ public class IndexTest : IClassFixture<TestApplication>
     public async Task OnPostUpdateTo0EmptyBasket()
     {
         // Load Home Page
-        var response = await Client.GetAsync("/");
+        var response = await Client.GetAsync("/", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse1 = await response.Content.ReadAsStringAsync();
+        var stringResponse1 = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         string token = WebPageHelpers.GetRequestVerificationToken(stringResponse1);
 
         // Add Item to Cart
         var keyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("id", "2"),
-            new KeyValuePair<string, string>("name", "shirt"),
-            new KeyValuePair<string, string>("__RequestVerificationToken", token)
+            new("id", "2"),
+            new("name", "shirt"),
+            new("__RequestVerificationToken", token)
         };
         var formContent = new FormUrlEncodedContent(keyValues);
-        var postResponse = await Client.PostAsync("/basket/index", formContent);
+        var postResponse = await Client.PostAsync("/basket/index", formContent, TestContext.Current.CancellationToken);
         postResponse.EnsureSuccessStatusCode();
-        var stringResponse = await postResponse.Content.ReadAsStringAsync();
+        var stringResponse = await postResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
         Assert.Contains(".NET Black &amp; White Mug", stringResponse);
 
         //Update
         var updateKeyValues = new List<KeyValuePair<string, string>>
         {
-            new KeyValuePair<string, string>("Items[0].Id", WebPageHelpers.GetId(stringResponse)),
-            new KeyValuePair<string, string>("Items[0].Quantity", "0"),
-            new KeyValuePair<string, string>(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse))
+            new("Items[0].Id", WebPageHelpers.GetId(stringResponse)),
+            new("Items[0].Quantity", "0"),
+            new(WebPageHelpers.TokenTag, WebPageHelpers.GetRequestVerificationToken(stringResponse))
         };
         var updateContent = new FormUrlEncodedContent(updateKeyValues);
-        var updateResponse = await Client.PostAsync("/basket/update", updateContent);
+        var updateResponse = await Client.PostAsync("/basket/update", updateContent, TestContext.Current.CancellationToken);
 
-        var stringUpdateResponse = await updateResponse.Content.ReadAsStringAsync();
+        var stringUpdateResponse = await updateResponse.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         Assert.Contains("/basket/update", updateResponse!.RequestMessage!.RequestUri!.ToString()!);
         Assert.Contains("Basket is empty", stringUpdateResponse);

--- a/tests/FunctionalTests/Web/Pages/HomePageOnGet.cs
+++ b/tests/FunctionalTests/Web/Pages/HomePageOnGet.cs
@@ -1,25 +1,20 @@
 ﻿using Microsoft.eShopWeb.FunctionalTests.Web;
 using Xunit;
 
-namespace Microsoft.eShopWeb.FunctionalTests.WebRazorPages;
+namespace Microsoft.eShopWeb.FunctionalTests.Web.Pages;
 
 [Collection("Sequential")]
-public class HomePageOnGet : IClassFixture<TestApplication>
+public class HomePageOnGet(TestApplication factory) : IClassFixture<TestApplication>
 {
-    public HomePageOnGet(TestApplication factory)
-    {
-        Client = factory.CreateClient();
-    }
-
-    public HttpClient Client { get; }
+    public HttpClient Client { get; } = factory.CreateClient();
 
     [Fact]
     public async Task ReturnsHomePageWithProductListing()
     {
         // Arrange & Act
-        var response = await Client.GetAsync("/");
+        var response = await Client.GetAsync("/", TestContext.Current.CancellationToken);
         response.EnsureSuccessStatusCode();
-        var stringResponse = await response.Content.ReadAsStringAsync();
+        var stringResponse = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
 
         // Assert
         Assert.Contains(".NET Bot Black Sweatshirt", stringResponse);

--- a/tests/FunctionalTests/Web/Pages/HomePageOnGet.cs
+++ b/tests/FunctionalTests/Web/Pages/HomePageOnGet.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.eShopWeb.FunctionalTests.Web;
-using Xunit;
+﻿using Xunit;
 
 namespace Microsoft.eShopWeb.FunctionalTests.Web.Pages;
 

--- a/tests/IntegrationTests/IntegrationTests.csproj
+++ b/tests/IntegrationTests/IntegrationTests.csproj
@@ -17,7 +17,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>

--- a/tests/IntegrationTests/Repositories/BasketRepositoryTests/SetQuantities.cs
+++ b/tests/IntegrationTests/Repositories/BasketRepositoryTests/SetQuantities.cs
@@ -13,7 +13,7 @@ public class SetQuantities
 {
     private readonly CatalogContext _catalogContext;
     private readonly EfRepository<Basket> _basketRepository;
-    private readonly BasketBuilder BasketBuilder = new BasketBuilder();
+    private readonly BasketBuilder _basketBuilder = new();
 
     public SetQuantities()
     {
@@ -27,12 +27,12 @@ public class SetQuantities
     [Fact]
     public async Task RemoveEmptyQuantities()
     {
-        var basket = BasketBuilder.WithOneBasketItem();
+        var basket = _basketBuilder.WithOneBasketItem();
         var basketService = new BasketService(_basketRepository, null);
-        await _basketRepository.AddAsync(basket);
+        await _basketRepository.AddAsync(basket, TestContext.Current.CancellationToken);
         _catalogContext.SaveChanges();
 
-        await basketService.SetQuantities(BasketBuilder.BasketId, new Dictionary<string, int>() { { BasketBuilder.BasketId.ToString(), 0 } });
+        await basketService.SetQuantities(_basketBuilder.BasketId, new Dictionary<string, int>() { { _basketBuilder.BasketId.ToString(), 0 } });
 
         Assert.Empty(basket.Items);
     }

--- a/tests/IntegrationTests/Repositories/OrderRepositoryTests/GetById.cs
+++ b/tests/IntegrationTests/Repositories/OrderRepositoryTests/GetById.cs
@@ -33,7 +33,7 @@ public class GetById
         int orderId = existingOrder.Id;
         _output.WriteLine($"OrderId: {orderId}");
 
-        var orderFromRepo = await _orderRepository.GetByIdAsync(orderId);
+        var orderFromRepo = await _orderRepository.GetByIdAsync(orderId, TestContext.Current.CancellationToken);
         Assert.Equal(OrderBuilder.TestBuyerId, orderFromRepo.BuyerId);
 
         // Note: Using InMemoryDatabase OrderItems is available. Will be null if using SQL DB.

--- a/tests/IntegrationTests/Repositories/OrderRepositoryTests/GetById.cs
+++ b/tests/IntegrationTests/Repositories/OrderRepositoryTests/GetById.cs
@@ -5,7 +5,6 @@ using Microsoft.eShopWeb.ApplicationCore.Entities.OrderAggregate;
 using Microsoft.eShopWeb.Infrastructure.Data;
 using Microsoft.eShopWeb.UnitTests.Builders;
 using Xunit;
-using Xunit.Abstractions;
 
 namespace Microsoft.eShopWeb.IntegrationTests.Repositories.OrderRepositoryTests;
 

--- a/tests/IntegrationTests/Repositories/OrderRepositoryTests/GetByIdWithItemsAsync.cs
+++ b/tests/IntegrationTests/Repositories/OrderRepositoryTests/GetByIdWithItemsAsync.cs
@@ -38,9 +38,11 @@ public class GetByIdWithItemsAsync
         _catalogContext.Orders.Add(firstOrder);
         int firstOrderId = firstOrder.Id;
 
-        var secondOrderItems = new List<OrderItem>();
-        secondOrderItems.Add(new OrderItem(OrderBuilder.TestCatalogItemOrdered, itemOneUnitPrice, itemOneUnits));
-        secondOrderItems.Add(new OrderItem(OrderBuilder.TestCatalogItemOrdered, itemTwoUnitPrice, itemTwoUnits));
+        var secondOrderItems = new List<OrderItem>
+        {
+            new(OrderBuilder.TestCatalogItemOrdered, itemOneUnitPrice, itemOneUnits),
+            new(OrderBuilder.TestCatalogItemOrdered, itemTwoUnitPrice, itemTwoUnits)
+        };
         var secondOrder = OrderBuilder.WithItems(secondOrderItems);
         _catalogContext.Orders.Add(secondOrder);
         int secondOrderId = secondOrder.Id;
@@ -49,7 +51,7 @@ public class GetByIdWithItemsAsync
 
         //Act
         var spec = new OrderWithItemsByIdSpec(secondOrderId);
-        var orderFromRepo = await _orderRepository.FirstOrDefaultAsync(spec);
+        var orderFromRepo = await _orderRepository.FirstOrDefaultAsync(spec, TestContext.Current.CancellationToken);
 
         //Assert
         Assert.Equal(secondOrderId, orderFromRepo.Id);

--- a/tests/UnitTests/ApplicationCore/Entities/OrderTests/OrderTotal.cs
+++ b/tests/UnitTests/ApplicationCore/Entities/OrderTests/OrderTotal.cs
@@ -6,7 +6,7 @@ namespace Microsoft.eShopWeb.UnitTests.ApplicationCore.Entities.OrderTests;
 
 public class OrderTotal
 {
-    private decimal _testUnitPrice = 42m;
+    private readonly decimal _testUnitPrice = 42m;
 
     [Fact]
     public void IsZeroForNewOrder()
@@ -22,7 +22,7 @@ public class OrderTotal
         var builder = new OrderBuilder();
         var items = new List<OrderItem>
             {
-                new OrderItem(builder.TestCatalogItemOrdered, _testUnitPrice, 1)
+                new(builder.TestCatalogItemOrdered, _testUnitPrice, 1)
             };
         var order = new OrderBuilder().WithItems(items);
         Assert.Equal(_testUnitPrice, order.Total());

--- a/tests/UnitTests/ApplicationCore/Services/BasketServiceTests/AddItemToBasket.cs
+++ b/tests/UnitTests/ApplicationCore/Services/BasketServiceTests/AddItemToBasket.cs
@@ -19,13 +19,13 @@ public class AddItemToBasket
         var basket = new Basket(_buyerId);
         basket.AddItem(1, 1.5m);
 
-        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default).Returns(basket);
+        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), Arg.Any<CancellationToken>()).Returns(basket);
 
         var basketService = new BasketService(_mockBasketRepo, _mockLogger);
 
         await basketService.AddItemToBasket(basket.BuyerId, 1, 1.50m);
 
-        await _mockBasketRepo.Received().FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default);
+        await _mockBasketRepo.Received().FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -33,12 +33,12 @@ public class AddItemToBasket
     {
         var basket = new Basket(_buyerId);
         basket.AddItem(1, 1.1m, 1);
-        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default).Returns(basket);
+        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), Arg.Any<CancellationToken>()).Returns(basket);
 
         var basketService = new BasketService(_mockBasketRepo, _mockLogger);
 
         await basketService.AddItemToBasket(basket.BuyerId, 1, 1.50m);
 
-        await _mockBasketRepo.Received().UpdateAsync(basket, default);
+        await _mockBasketRepo.Received().UpdateAsync(basket, Arg.Any<CancellationToken>());
     }
 }

--- a/tests/UnitTests/ApplicationCore/Services/BasketServiceTests/DeleteBasket.cs
+++ b/tests/UnitTests/ApplicationCore/Services/BasketServiceTests/DeleteBasket.cs
@@ -19,12 +19,12 @@ public class DeleteBasket
         var basket = new Basket(_buyerId);
         basket.AddItem(1, 1.1m, 1);
         basket.AddItem(2, 1.1m, 1);
-        _mockBasketRepo.GetByIdAsync(Arg.Any<int>(), default)
+        _mockBasketRepo.GetByIdAsync(Arg.Any<int>(), Arg.Any<CancellationToken>())
             .Returns(basket);
         var basketService = new BasketService(_mockBasketRepo, _mockLogger);
 
         await basketService.DeleteBasketAsync(1);
 
-        await _mockBasketRepo.Received().DeleteAsync(Arg.Any<Basket>(), default);
+        await _mockBasketRepo.Received().DeleteAsync(Arg.Any<Basket>(), Arg.Any<CancellationToken>());
     }
 }

--- a/tests/UnitTests/ApplicationCore/Services/BasketServiceTests/TransferBasket.cs
+++ b/tests/UnitTests/ApplicationCore/Services/BasketServiceTests/TransferBasket.cs
@@ -39,10 +39,10 @@ public class TransferBasket
                         .Then(userBasket);
 
 
-        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default).Returns(x => results.Next());          
+        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), Arg.Any<CancellationToken>()).Returns(x => results.Next());          
         var basketService = new BasketService(_mockBasketRepo, _mockLogger);
         await basketService.TransferBasketAsync(_nonexistentAnonymousBasketBuyerId, _existentUserBasketBuyerId);
-        await _mockBasketRepo.Received().FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default);
+        await _mockBasketRepo.Received().FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -58,7 +58,7 @@ public class TransferBasket
         var results = new Results<Basket>(anonymousBasket)
                         .Then(userBasket);
 
-        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default).Returns(x => results.Next());
+        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), Arg.Any<CancellationToken>()).Returns(x => results.Next());
         var basketService = new BasketService(_mockBasketRepo, _mockLogger);
         await basketService.TransferBasketAsync(_nonexistentAnonymousBasketBuyerId, _existentUserBasketBuyerId);
         await _mockBasketRepo.Received().UpdateAsync(userBasket, default);
@@ -78,11 +78,11 @@ public class TransferBasket
         var results = new Results<Basket>(anonymousBasket)
                         .Then(userBasket);
 
-        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default).Returns(x => results.Next());
+        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), Arg.Any<CancellationToken>()).Returns(x => results.Next());
         var basketService = new BasketService(_mockBasketRepo, _mockLogger);
         await basketService.TransferBasketAsync(_nonexistentAnonymousBasketBuyerId, _existentUserBasketBuyerId);
-        await _mockBasketRepo.Received().UpdateAsync(userBasket, default);
-        await _mockBasketRepo.Received().DeleteAsync(anonymousBasket, default);
+        await _mockBasketRepo.Received().UpdateAsync(userBasket, Arg.Any<CancellationToken>());
+        await _mockBasketRepo.Received().DeleteAsync(anonymousBasket, Arg.Any<CancellationToken>());
     }
 
     [Fact]
@@ -94,9 +94,9 @@ public class TransferBasket
         var results = new Results<Basket?>(anonymousBasket)
                        .Then(userBasket);
 
-        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>(), default).Returns(x => results.Next());
+        _mockBasketRepo.FirstOrDefaultAsync(Arg.Any<BasketWithItemsSpecification>()).Returns(x => results.Next());
         var basketService = new BasketService(_mockBasketRepo, _mockLogger);
         await basketService.TransferBasketAsync(_existentAnonymousBasketBuyerId, _nonexistentUserBasketBuyerId);
-        await _mockBasketRepo.Received().AddAsync(Arg.Is<Basket>(x => x.BuyerId == _nonexistentUserBasketBuyerId), default);
+        await _mockBasketRepo.Received().AddAsync(Arg.Is<Basket>(x => x.BuyerId == _nonexistentUserBasketBuyerId));
     }
 }

--- a/tests/UnitTests/MediatorHandlers/OrdersTests/GetMyOrders.cs
+++ b/tests/UnitTests/MediatorHandlers/OrdersTests/GetMyOrders.cs
@@ -17,7 +17,7 @@ public class GetMyOrders
         var address = new Address("", "", "", "", "");
         Order order = new Order("buyerId", address, new List<OrderItem> { item });
               
-        _mockOrderRepository.ListAsync(Arg.Any<ISpecification<Order>>(), default).Returns(new List<Order> { order });
+        _mockOrderRepository.ListAsync(Arg.Any<ISpecification<Order>>(), Arg.Any<CancellationToken>()).Returns(new List<Order> { order });
     }
 
     [Fact]
@@ -27,7 +27,7 @@ public class GetMyOrders
 
         var handler = new GetMyOrdersHandler(_mockOrderRepository);
 
-        var result = await handler.Handle(request, CancellationToken.None);
+        var result = await handler.Handle(request, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
     }

--- a/tests/UnitTests/MediatorHandlers/OrdersTests/GetOrderDetails.cs
+++ b/tests/UnitTests/MediatorHandlers/OrdersTests/GetOrderDetails.cs
@@ -17,7 +17,7 @@ public class GetOrderDetails
         var address = new Address("", "", "", "", "");
         Order order = new Order("buyerId", address, new List<OrderItem> { item });
                 
-        _mockOrderRepository.FirstOrDefaultAsync(Arg.Any<OrderWithItemsByIdSpec>(), default)
+        _mockOrderRepository.FirstOrDefaultAsync(Arg.Any<OrderWithItemsByIdSpec>(), Arg.Any<CancellationToken>())
             .Returns(order);
     }
 
@@ -28,7 +28,7 @@ public class GetOrderDetails
 
         var handler = new GetOrderDetailsHandler(_mockOrderRepository);
 
-        var result = await handler.Handle(request, CancellationToken.None);
+        var result = await handler.Handle(request, TestContext.Current.CancellationToken);
 
         Assert.NotNull(result);
     }

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -19,12 +19,12 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.v3" />
     <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>      
-    <PackageReference Include="xunit.runner.console" />     
+    <PackageReference Include="xunit.v3.runner.console" />     
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Closes #223 

- Updates xUnit references to latest stable xunit.v3 version
- Removes references to Xunit.Abstractions
- Updates `CancellationToken` handling with the xUnit analyzer guidance - [xUnit1051](https://xunit.net/xunit.analyzers/rules/xUnit1051)
  - Replaces `default` values of `Cancellation` to either `Arg.Any<CancellationToken>()` or `TestContext.Current.CancellationToken`, depending on the code situation
  - No more `CancellationToken.None` - Thanks to @sdepouw for this call-out!